### PR TITLE
Fix(release-v1.5): Ensure Database Names are Initialized in Lowercase on macOS

### DIFF
--- a/deployments/templates/config.yaml
+++ b/deployments/templates/config.yaml
@@ -54,7 +54,7 @@ mysql:
    address: [ 172.28.0.1:13306 ]            # MYSQL_ADDRESS and MYSQL_PORT, MySQL server address and port
    username: root                          # MYSQL_USERNAME, Username for MySQL
    password: openIM123                     # MYSQL_PASSWORD, Password for MySQL
-   database: openIM_v3                     # MYSQL_DATABASE, Database name
+   database: openim_v3                     # MYSQL_DATABASE, Database name
    maxOpenConn: 1000                       # Max open connections
    maxIdleConn: 100                        # Max idle connections
    maxLifeTime: 60                         # Max lifetime of connections in seconds


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?

/kind documentation
/kind feature

<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->

## Overview
This Pull Request addresses an issue specific to deployment on macOS, where database names are automatically converted from uppercase to lowercase. This behavior can lead to inconsistencies and potential issues in environments where case sensitivity is important.

## Changes Made
- Implemented a fix that ensures all database names are initialized in lowercase. This applies to all instances where databases are created or referenced within the system.
- Added checks to prevent the creation of databases with uppercase names, enforcing a lowercase naming convention across the platform.

## Impact
- This change promotes consistency in database naming conventions, particularly in cross-platform setups.
- It prevents the potential issues that arise from the automatic conversion of database names from uppercase to lowercase on macOS, ensuring smoother operations and deployment.

## Testing
- Comprehensive tests have been added to validate the enforcement of lowercase database names during the initialization process.
- Cross-platform testing has been conducted to ensure that these changes do not adversely affect deployments on other operating systems.

