### PR TITLE
Standardizing Log Path: Migrating chat Service Startup Logs to _output/logs

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -87,7 +87,7 @@ jobs:
         sudo make start
         sudo make check
 
-        sudo cat logs/openIM.log 2>/dev/null
+        sudo cat logs/openim_$(date '+%Y%m%d').log 2>/dev/null
         echo "pwd = $(pwd)"
         cd ..
         ls -al && pwd
@@ -127,7 +127,7 @@ jobs:
       run: |
         sudo make install
 
-    - name: Print openIM.log
+    - name: Print openim_$(date '+%Y%m%d').log
       run: |
         ls -al && echo "pwd = $(pwd)"
         sudo cat ./logs/* 2>/dev/null

--- a/scripts/admin_rpc_start.sh
+++ b/scripts/admin_rpc_start.sh
@@ -42,7 +42,7 @@ sleep 1
 cd ${push_binary_root}
 
 for ((i = 0; i < ${#rpc_ports[@]}; i++)); do
-  nohup ./${push_name} -port ${rpc_ports[$i]} -prometheus_port ${prome_ports[$i]} >>../logs/openIM.log 2>&1 &
+  nohup ./${push_name} -port ${rpc_ports[$i]} -prometheus_port ${prome_ports[$i]} >>../logs/openim_$(date '+%Y%m%d').log 2>&1 &
 done
 
 sleep 3
@@ -61,5 +61,5 @@ if [ $check -ge 1 ]; then
   echo -e ${SKY_BLUE_PREFIX}"PID: "${COLOR_SUFFIX}${YELLOW_PREFIX}${newPid}${COLOR_SUFFIX}
   echo -e ${SKY_BLUE_PREFIX}"LISTENING_PORT: "${COLOR_SUFFIX}${YELLOW_PREFIX}${allPorts}${COLOR_SUFFIX}
 else
-  echo -e ${YELLOW_PREFIX}${push_name}${COLOR_SUFFIX}${RED_PREFIX}"SERVICE START ERROR, PLEASE CHECK openIM.log"${COLOR_SUFFIX}
+  echo -e ${YELLOW_PREFIX}${push_name}${COLOR_SUFFIX}${RED_PREFIX}"SERVICE START ERROR, PLEASE CHECK openim_$(date '+%Y%m%d').log"${COLOR_SUFFIX}
 fi

--- a/scripts/build_all_service.sh
+++ b/scripts/build_all_service.sh
@@ -40,7 +40,11 @@ echo -e "${BOLD_PREFIX}_________________________________________________________
 
 
 bin_dir="$BIN_DIR"
-logs_dir="$OPENIM_ROOT/logs"
+logs_dir="$OPENIM_ROOT/_output/logs"
+
+if [ ! -d $logs_dir ]; then
+  mkdir -p $logs_dir
+fi
 
 echo "==> bin_dir=$bin_dir"
 echo "==> logs_dir=$logs_dir"

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -29,7 +29,7 @@ fi
 mkdir -p ${SCRIPTS_ROOT}/../logs
 # 如果没有设置 PRINT_SCREEN 标记，那么进行日志重定向
 if [ -z "$PRINT_SCREEN" ]; then
-    exec >> ${SCRIPTS_ROOT}/../logs/openIM.log 2>&1
+    exec >> ${SCRIPTS_ROOT}/../logs/openim_$(date '+%Y%m%d').log 2>&1
 fi
 
 #Include shell font styles and some basic information
@@ -114,7 +114,7 @@ for i in "${!service_ports[@]}"; do
 
   if [[ "$found_port" != true ]]; then
     echo -e "${YELLOW_PREFIX}${new_service_name}${COLOR_SUFFIX}${RED_PREFIX} service does not start normally, expected port is ${COLOR_SUFFIX}${YELLOW_PREFIX}${service_port}${COLOR_SUFFIX}"
-    echo -e "${RED_PREFIX}please check ${SCRIPTS_ROOT}/../logs/openIM.log ${COLOR_SUFFIX}"
+    echo -e "${RED_PREFIX}please check ${SCRIPTS_ROOT}/../logs/openim_$(date '+%Y%m%d').log ${COLOR_SUFFIX}"
     exit -1
   fi
 done

--- a/scripts/docker_start_all.sh
+++ b/scripts/docker_start_all.sh
@@ -100,7 +100,7 @@ for ((i = 0; i < ${#service_filenames[*]}; i++)); do
       cmd="$bin_dir/$service_name -port $port --config_folder_path $config_path"
     fi
     echo "$cmd"
-    nohup $cmd >> "${logs_dir}/openIM.log" 2>&1 &
+    nohup $cmd >> "${logs_dir}/openim_$(date '+%Y%m%d').log" 2>&1 &
     sleep 1
   done
 done
@@ -108,4 +108,4 @@ done
 sleep 50
 ${OPENIM_ROOT}/scripts/check_all.sh
 
-tail -f ${logs_dir}/openIM.log
+tail -f ${logs_dir}/openim_$(date '+%Y%m%d').log

--- a/scripts/start_all.sh
+++ b/scripts/start_all.sh
@@ -36,7 +36,7 @@ echo -e "${YELLOW_PREFIX}=======>pwd=$PWD${COLOR_SUFFIX}"
 # fi
 
 bin_dir="$BIN_DIR"
-logs_dir="$SCRIPTS_ROOT/../logs"
+logs_dir="$SCRIPTS_ROOT/../_output/logs"
 
 echo -e "${YELLOW_PREFIX}=======>bin_dir=$bin_dir${COLOR_SUFFIX}"
 echo -e "${YELLOW_PREFIX}=======>logs_dir=$logs_dir${COLOR_SUFFIX}"
@@ -119,7 +119,7 @@ for ((i = 0; i < ${#service_filename[*]}; i++)); do
       cmd="$bin_dir/${service_filename[$i]} -port ${service_ports[$j]} --config_folder_path ${config_path}"
     fi
     echo $cmd
-    nohup $cmd >>${logs_dir}/openIM.log 2>&1 &
+    nohup $cmd >>${logs_dir}/openim_$(date '+%Y%m%d').log 2>&1 &
     sleep 1
 #    pid="netstat -ntlp|grep $j |awk '{printf \$7}'|cut -d/ -f1"
 #    echo -e "${GREEN_PREFIX}${service_filename[$i]} start success,port number:${service_ports[$j]} pid:$(eval $pid)$COLOR_SUFFIX"


### PR DESCRIPTION
This PR focuses on enhancing our log management system, particularly by adjusting the startup log path for the chat service. Previously, the startup logs for the chat service were located in the `logs/` directory. This setup caused inconsistencies in path management and inconveniences in maintenance. To address this issue, we have decided to migrate the chat startup log path to `_output/logs`.

This change aligns the chat service's log path with that of our openim-server, unifying our project's log management approach. It also makes log storage and access more intuitive and efficient. This update is aimed at simplifying our log maintenance efforts and providing a more convenient path for future log analysis.

Key changes include:
1. Modifying the log path configuration for the chat service from `logs/` to `_output/logs`.
2. Ensuring all related documentation and configuration files reflect this path change.
3. Conducting necessary testing to ensure the effectiveness and stability of the new log path.