### PR TITLE
cicd: update chat makefile fix go version minimun 1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ SPACE +=
 # ==============================================================================
 # Build definition
 
-GO_SUPPORTED_VERSIONS ?= 1.19|1.20|1.21|1.22
+GO_SUPPORTED_VERSIONS ?= 1.21|1.22|1.23|1.24
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitVersion=$(VERSION) \
 	-X $(VERSION_PACKAGE).gitCommit=$(GIT_COMMIT) \
 	-X $(VERSION_PACKAGE).gitTreeState=$(GIT_TREE_STATE) \


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?
/kind flake

<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

<!--Why do we need this PR?-->

This PR represents a crucial update to our chat application's compatibility matrix by modifying the minimum version requirement to embrace a broader range of Go supported versions. Specifically, we are expanding the GO_SUPPORTED_VERSIONS parameter to include versions 1.21, 1.22, 1.23, and 1.24. This adjustment ensures our application remains aligned with current Go standards, offering enhanced stability, security, and performance benefits inherent in these versions. By accommodating a wider spectrum of Go environments, we are not only future-proofing our application but also providing our developers and users with the flexibility to operate within their preferred Go ecosystem. This update underscores our commitment to leveraging cutting-edge technology to deliver a robust and reliable chat experience.