### PR TITLE
refactor: renamed non-standard package aliases and field names.

### DIFF
--- a/internal/api/chat/chat.go
+++ b/internal/api/chat/chat.go
@@ -15,25 +15,26 @@
 package chat
 
 import (
-	"github.com/openimsdk/chat/internal/api/util"
 	"io"
 	"time"
 
+	"github.com/openimsdk/chat/internal/api/util"
+
 	"github.com/gin-gonic/gin"
 	"github.com/openimsdk/chat/pkg/common/apistruct"
-	chatconstant "github.com/openimsdk/chat/pkg/common/constant"
+	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/common/imapi"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
-	"github.com/openimsdk/chat/pkg/protocol/chat"
-	"github.com/openimsdk/protocol/constant"
+	chatpb "github.com/openimsdk/chat/pkg/protocol/chat"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/protocol/sdkws"
 	"github.com/openimsdk/tools/a2r"
 	"github.com/openimsdk/tools/apiresp"
 	"github.com/openimsdk/tools/errs"
 )
 
-func New(chatClient chat.ChatClient, adminClient admin.AdminClient, imApiCaller imapi.CallerInterface, api *util.Api) *Api {
+func New(chatClient chatpb.ChatClient, adminClient admin.AdminClient, imApiCaller imapi.CallerInterface, api *util.Api) *Api {
 	return &Api{
 		Api:         api,
 		chatClient:  chatClient,
@@ -44,7 +45,7 @@ func New(chatClient chat.ChatClient, adminClient admin.AdminClient, imApiCaller 
 
 type Api struct {
 	*util.Api
-	chatClient  chat.ChatClient
+	chatClient  chatpb.ChatClient
 	adminClient admin.AdminClient
 	imApiCaller imapi.CallerInterface
 }
@@ -52,7 +53,7 @@ type Api struct {
 // ################## ACCOUNT ##################
 
 func (o *Api) SendVerifyCode(c *gin.Context) {
-	req, err := a2r.ParseRequest[chat.SendVerifyCodeReq](c)
+	req, err := a2r.ParseRequest[chatpb.SendVerifyCodeReq](c)
 	if err != nil {
 		apiresp.GinError(c, err)
 		return
@@ -72,11 +73,11 @@ func (o *Api) SendVerifyCode(c *gin.Context) {
 }
 
 func (o *Api) VerifyCode(c *gin.Context) {
-	a2r.Call(chat.ChatClient.VerifyCode, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.VerifyCode, o.chatClient, c)
 }
 
 func (o *Api) RegisterUser(c *gin.Context) {
-	req, err := a2r.ParseRequest[chat.RegisterUserReq](c)
+	req, err := a2r.ParseRequest[chatpb.RegisterUserReq](c)
 	if err != nil {
 		apiresp.GinError(c, err)
 		return
@@ -130,7 +131,7 @@ func (o *Api) RegisterUser(c *gin.Context) {
 }
 
 func (o *Api) Login(c *gin.Context) {
-	req, err := a2r.ParseRequest[chat.LoginReq](c)
+	req, err := a2r.ParseRequest[chatpb.LoginReq](c)
 	if err != nil {
 		apiresp.GinError(c, err)
 		return
@@ -159,17 +160,17 @@ func (o *Api) Login(c *gin.Context) {
 }
 
 func (o *Api) ResetPassword(c *gin.Context) {
-	a2r.Call(chat.ChatClient.ResetPassword, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.ResetPassword, o.chatClient, c)
 }
 
 func (o *Api) ChangePassword(c *gin.Context) {
-	a2r.Call(chat.ChatClient.ChangePassword, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.ChangePassword, o.chatClient, c)
 }
 
 // ################## USER ##################
 
 func (o *Api) UpdateUserInfo(c *gin.Context) {
-	req, err := a2r.ParseRequest[chat.UpdateUserInfoReq](c)
+	req, err := a2r.ParseRequest[chatpb.UpdateUserInfoReq](c)
 	if err != nil {
 		apiresp.GinError(c, err)
 		return
@@ -185,10 +186,10 @@ func (o *Api) UpdateUserInfo(c *gin.Context) {
 		return
 	}
 	var imToken string
-	if opUserType == chatconstant.NormalUser {
+	if opUserType == constant.NormalUser {
 		imToken, err = o.imApiCaller.ImAdminTokenWithDefaultAdmin(c)
-	} else if opUserType == chatconstant.AdminUser {
-		imToken, err = o.imApiCaller.UserToken(c, o.GetDefaultIMAdminUserID(), constant.AdminPlatformID)
+	} else if opUserType == constant.AdminUser {
+		imToken, err = o.imApiCaller.UserToken(c, o.GetDefaultIMAdminUserID(), constantpb.AdminPlatformID)
 	} else {
 		apiresp.GinError(c, errs.ErrArgs.WrapMsg("opUserType unknown"))
 		return
@@ -220,23 +221,23 @@ func (o *Api) UpdateUserInfo(c *gin.Context) {
 }
 
 func (o *Api) FindUserPublicInfo(c *gin.Context) {
-	a2r.Call(chat.ChatClient.FindUserPublicInfo, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.FindUserPublicInfo, o.chatClient, c)
 }
 
 func (o *Api) FindUserFullInfo(c *gin.Context) {
-	a2r.Call(chat.ChatClient.FindUserFullInfo, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.FindUserFullInfo, o.chatClient, c)
 }
 
 func (o *Api) SearchUserFullInfo(c *gin.Context) {
-	a2r.Call(chat.ChatClient.SearchUserFullInfo, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.SearchUserFullInfo, o.chatClient, c)
 }
 
 func (o *Api) SearchUserPublicInfo(c *gin.Context) {
-	a2r.Call(chat.ChatClient.SearchUserPublicInfo, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.SearchUserPublicInfo, o.chatClient, c)
 }
 
 func (o *Api) GetTokenForVideoMeeting(c *gin.Context) {
-	a2r.Call(chat.ChatClient.GetTokenForVideoMeeting, o.chatClient, c)
+	a2r.Call(chatpb.ChatClient.GetTokenForVideoMeeting, o.chatClient, c)
 }
 
 // ################## APPLET ##################
@@ -259,8 +260,8 @@ func (o *Api) OpenIMCallback(c *gin.Context) {
 		apiresp.GinError(c, err)
 		return
 	}
-	req := &chat.OpenIMCallbackReq{
-		Command: c.Query(constant.CallbackCommand),
+	req := &chatpb.OpenIMCallbackReq{
+		Command: c.Query(constantpb.CallbackCommand),
 		Body:    string(body),
 	}
 	if _, err := o.chatClient.OpenIMCallback(c, req); err != nil {
@@ -273,7 +274,7 @@ func (o *Api) OpenIMCallback(c *gin.Context) {
 func (o *Api) SearchFriend(c *gin.Context) {
 	req, err := a2r.ParseRequest[struct {
 		UserID string `json:"userID"`
-		chat.SearchUserInfoReq
+		chatpb.SearchUserInfoReq
 	}](c)
 	if err != nil {
 		apiresp.GinError(c, err)
@@ -293,7 +294,7 @@ func (o *Api) SearchFriend(c *gin.Context) {
 		return
 	}
 	if len(userIDs) == 0 {
-		apiresp.GinSuccess(c, &chat.SearchUserInfoResp{})
+		apiresp.GinSuccess(c, &chatpb.SearchUserInfoResp{})
 		return
 	}
 	req.SearchUserInfoReq.UserIDs = userIDs

--- a/internal/api/chat/start.go
+++ b/internal/api/chat/start.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"fmt"
+
 	"github.com/gin-gonic/gin"
 	chatmw "github.com/openimsdk/chat/internal/api/mw"
 	"github.com/openimsdk/chat/internal/api/util"

--- a/internal/api/mw/mw.go
+++ b/internal/api/mw/mw.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
-	constant2 "github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/apiresp"
 	"github.com/openimsdk/tools/errs"
 )
@@ -66,8 +66,8 @@ func (o *MW) isValidToken(c *gin.Context, userID string, token string) error {
 	}
 	if v, ok := resp.TokensMap[token]; ok {
 		switch v {
-		case constant2.NormalToken:
-		case constant2.KickedToken:
+		case constantpb.NormalToken:
+		case constantpb.KickedToken:
 			return errs.ErrTokenExpired.Wrap()
 		default:
 			return errs.ErrTokenUnknown.Wrap()

--- a/internal/rpc/admin/admin.go
+++ b/internal/rpc/admin/admin.go
@@ -17,15 +17,16 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/openimsdk/tools/errs"
-	"github.com/openimsdk/tools/mcontext"
-	"github.com/openimsdk/tools/utils/datautil"
 	"math/rand"
 	"time"
 
+	"github.com/openimsdk/tools/errs"
+	"github.com/openimsdk/tools/mcontext"
+	"github.com/openimsdk/tools/utils/datautil"
+
 	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/common/db/dbutil"
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/eerrs"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
@@ -77,7 +78,7 @@ func (o *adminServer) AddAdminAccount(ctx context.Context, req *admin.AddAdminAc
 		return nil, errs.ErrDuplicateKey.WrapMsg("the account is registered")
 	}
 
-	adm := &admin2.Admin{
+	adm := &admindb.Admin{
 		Account:    req.Account,
 		Password:   req.Password,
 		FaceURL:    req.FaceURL,
@@ -86,7 +87,7 @@ func (o *adminServer) AddAdminAccount(ctx context.Context, req *admin.AddAdminAc
 		Level:      80,
 		CreateTime: time.Now(),
 	}
-	if err = o.Database.AddAdminAccount(ctx, []*admin2.Admin{adm}); err != nil {
+	if err = o.Database.AddAdminAccount(ctx, []*admindb.Admin{adm}); err != nil {
 		return nil, err
 	}
 	return &admin.AddAdminAccountResp{}, nil

--- a/internal/rpc/admin/applet.go
+++ b/internal/rpc/admin/applet.go
@@ -16,15 +16,16 @@ package admin
 
 import (
 	"context"
-	"github.com/openimsdk/tools/utils/datautil"
 	"strings"
 	"time"
+
+	"github.com/openimsdk/tools/utils/datautil"
 
 	"github.com/google/uuid"
 	"github.com/openimsdk/tools/errs"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 	"github.com/openimsdk/chat/pkg/protocol/common"
@@ -43,7 +44,7 @@ func (o *adminServer) AddApplet(ctx context.Context, req *admin.AddAppletReq) (*
 	if !(req.Status == constant.StatusOnShelf || req.Status == constant.StatusUnShelf) {
 		return nil, errs.ErrArgs.WrapMsg("invalid status")
 	}
-	m := admin2.Applet{
+	m := admindb.Applet{
 		ID:         req.Id,
 		Name:       req.Name,
 		AppID:      req.AppID,
@@ -59,7 +60,7 @@ func (o *adminServer) AddApplet(ctx context.Context, req *admin.AddAppletReq) (*
 	if m.ID == "" {
 		m.ID = uuid.New().String()
 	}
-	if err := o.Database.CreateApplet(ctx, []*admin2.Applet{&m}); err != nil {
+	if err := o.Database.CreateApplet(ctx, []*admindb.Applet{&m}); err != nil {
 		return nil, err
 	}
 	return &admin.AddAppletResp{}, nil
@@ -76,7 +77,7 @@ func (o *adminServer) DelApplet(ctx context.Context, req *admin.DelAppletReq) (*
 	if err != nil {
 		return nil, err
 	}
-	if ids := datautil.Single(req.AppletIds, datautil.Slice(applets, func(e *admin2.Applet) string { return e.ID })); len(ids) > 0 {
+	if ids := datautil.Single(req.AppletIds, datautil.Slice(applets, func(e *admindb.Applet) string { return e.ID })); len(ids) > 0 {
 		return nil, errs.ErrArgs.WrapMsg("ids not found: " + strings.Join(ids, ", "))
 	}
 	if err := o.Database.DelApplet(ctx, req.AppletIds); err != nil {

--- a/internal/rpc/admin/check.go
+++ b/internal/rpc/admin/check.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/chat/pkg/common/db/dbutil"
 	"github.com/openimsdk/chat/pkg/eerrs"
 	"github.com/openimsdk/chat/pkg/protocol/admin"

--- a/internal/rpc/admin/ip_forbidden.go
+++ b/internal/rpc/admin/ip_forbidden.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 )
@@ -51,9 +51,9 @@ func (o *adminServer) AddIPForbidden(ctx context.Context, req *admin.AddIPForbid
 		return nil, err
 	}
 	now := time.Now()
-	tables := make([]*admin2.IPForbidden, 0, len(req.Forbiddens))
+	tables := make([]*admindb.IPForbidden, 0, len(req.Forbiddens))
 	for _, forbidden := range req.Forbiddens {
-		tables = append(tables, &admin2.IPForbidden{
+		tables = append(tables, &admindb.IPForbidden{
 			IP:            forbidden.Ip,
 			LimitLogin:    forbidden.LimitLogin,
 			LimitRegister: forbidden.LimitRegister,

--- a/internal/rpc/admin/register_add_friend.go
+++ b/internal/rpc/admin/register_add_friend.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/openimsdk/tools/errs"
 
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 	"github.com/openimsdk/chat/pkg/protocol/common"
@@ -52,9 +52,9 @@ func (o *adminServer) AddDefaultFriend(ctx context.Context, req *admin.AddDefaul
 		return nil, errs.ErrDuplicateKey.WrapMsg("user id existed", "userID", exists)
 	}
 	now := time.Now()
-	ms := make([]*admin2.RegisterAddFriend, 0, len(req.UserIDs))
+	ms := make([]*admindb.RegisterAddFriend, 0, len(req.UserIDs))
 	for _, userID := range req.UserIDs {
-		ms = append(ms, &admin2.RegisterAddFriend{
+		ms = append(ms, &admindb.RegisterAddFriend{
 			UserID:     userID,
 			CreateTime: now,
 		})
@@ -83,9 +83,9 @@ func (o *adminServer) DelDefaultFriend(ctx context.Context, req *admin.DelDefaul
 		return nil, errs.ErrRecordNotFound.WrapMsg("user id not found", "userID", ids)
 	}
 	now := time.Now()
-	ms := make([]*admin2.RegisterAddFriend, 0, len(req.UserIDs))
+	ms := make([]*admindb.RegisterAddFriend, 0, len(req.UserIDs))
 	for _, userID := range req.UserIDs {
-		ms = append(ms, &admin2.RegisterAddFriend{
+		ms = append(ms, &admindb.RegisterAddFriend{
 			UserID:     userID,
 			CreateTime: now,
 		})
@@ -115,7 +115,7 @@ func (o *adminServer) SearchDefaultFriend(ctx context.Context, req *admin.Search
 	if err != nil {
 		return nil, err
 	}
-	userIDs := datautil.Slice(infos, func(info *admin2.RegisterAddFriend) string { return info.UserID })
+	userIDs := datautil.Slice(infos, func(info *admindb.RegisterAddFriend) string { return info.UserID })
 	userMap, err := o.Chat.MapUserPublicInfo(ctx, userIDs)
 	if err != nil {
 		return nil, err

--- a/internal/rpc/admin/register_add_group.go
+++ b/internal/rpc/admin/register_add_group.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/openimsdk/tools/errs"
 
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 )
@@ -44,9 +44,9 @@ func (o *adminServer) AddDefaultGroup(ctx context.Context, req *admin.AddDefault
 		return nil, errs.ErrDuplicateKey.WrapMsg("group id existed", "groupID", exists)
 	}
 	now := time.Now()
-	ms := make([]*admin2.RegisterAddGroup, 0, len(req.GroupIDs))
+	ms := make([]*admindb.RegisterAddGroup, 0, len(req.GroupIDs))
 	for _, groupID := range req.GroupIDs {
-		ms = append(ms, &admin2.RegisterAddGroup{
+		ms = append(ms, &admindb.RegisterAddGroup{
 			GroupID:    groupID,
 			CreateTime: now,
 		})
@@ -75,9 +75,9 @@ func (o *adminServer) DelDefaultGroup(ctx context.Context, req *admin.DelDefault
 		return nil, errs.ErrRecordNotFound.WrapMsg("group id not found", "groupID", ids)
 	}
 	now := time.Now()
-	ms := make([]*admin2.RegisterAddGroup, 0, len(req.GroupIDs))
+	ms := make([]*admindb.RegisterAddGroup, 0, len(req.GroupIDs))
 	for _, groupID := range req.GroupIDs {
-		ms = append(ms, &admin2.RegisterAddGroup{
+		ms = append(ms, &admindb.RegisterAddGroup{
 			GroupID:    groupID,
 			CreateTime: now,
 		})
@@ -107,5 +107,5 @@ func (o *adminServer) SearchDefaultGroup(ctx context.Context, req *admin.SearchD
 	if err != nil {
 		return nil, err
 	}
-	return &admin.SearchDefaultGroupResp{Total: uint32(total), GroupIDs: datautil.Slice(infos, func(info *admin2.RegisterAddGroup) string { return info.GroupID })}, nil
+	return &admin.SearchDefaultGroupResp{Total: uint32(total), GroupIDs: datautil.Slice(infos, func(info *admindb.RegisterAddGroup) string { return info.GroupID })}, nil
 }

--- a/internal/rpc/admin/start.go
+++ b/internal/rpc/admin/start.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"math/rand"
+	"time"
+
 	"github.com/openimsdk/chat/pkg/common/config"
 	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/common/db/database"
 	"github.com/openimsdk/chat/pkg/common/db/dbutil"
 	"github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/tokenverify"
-	pbadmin "github.com/openimsdk/chat/pkg/protocol/admin"
+	adminpb "github.com/openimsdk/chat/pkg/protocol/admin"
 	"github.com/openimsdk/chat/pkg/protocol/chat"
 	chatClient "github.com/openimsdk/chat/pkg/rpclient/chat"
 	"github.com/openimsdk/tools/db/mongoutil"
@@ -20,8 +23,6 @@ import (
 	"github.com/openimsdk/tools/mw"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"math/rand"
-	"time"
 )
 
 type Config struct {
@@ -62,7 +63,7 @@ func Start(ctx context.Context, config *Config, client discovery.SvcDiscoveryReg
 	if err := srv.initAdmin(ctx, config.Share.ChatAdmin, config.Share.OpenIM.AdminUserID); err != nil {
 		return err
 	}
-	pbadmin.RegisterAdminServer(server, &srv)
+	adminpb.RegisterAdminServer(server, &srv)
 	return nil
 }
 

--- a/internal/rpc/admin/user.go
+++ b/internal/rpc/admin/user.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/openimsdk/chat/pkg/common/db/dbutil"
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 	"github.com/openimsdk/chat/pkg/protocol/chat"
@@ -54,13 +54,13 @@ func (o *adminServer) BlockUser(ctx context.Context, req *admin.BlockUserReq) (*
 		return nil, err
 	}
 
-	t := &admin2.ForbiddenAccount{
+	t := &admindb.ForbiddenAccount{
 		UserID:         req.UserID,
 		Reason:         req.Reason,
 		OperatorUserID: mcontext.GetOpUserID(ctx),
 		CreateTime:     time.Now(),
 	}
-	if err := o.Database.BlockUser(ctx, []*admin2.ForbiddenAccount{t}); err != nil {
+	if err := o.Database.BlockUser(ctx, []*admindb.ForbiddenAccount{t}); err != nil {
 		return nil, err
 	}
 	return &admin.BlockUserResp{}, nil
@@ -81,7 +81,7 @@ func (o *adminServer) UnblockUser(ctx context.Context, req *admin.UnblockUserReq
 		return nil, err
 	}
 	if len(req.UserIDs) != len(bs) {
-		ids := datautil.Single(req.UserIDs, datautil.Slice(bs, func(info *admin2.ForbiddenAccount) string { return info.UserID }))
+		ids := datautil.Single(req.UserIDs, datautil.Slice(bs, func(info *admindb.ForbiddenAccount) string { return info.UserID }))
 		return nil, errs.ErrArgs.WrapMsg("user not blocked " + strings.Join(ids, ", "))
 	}
 	if err := o.Database.DelBlockUser(ctx, req.UserIDs); err != nil {
@@ -98,7 +98,7 @@ func (o *adminServer) SearchBlockUser(ctx context.Context, req *admin.SearchBloc
 	if err != nil {
 		return nil, err
 	}
-	userIDs := datautil.Slice(infos, func(info *admin2.ForbiddenAccount) string { return info.UserID })
+	userIDs := datautil.Slice(infos, func(info *admindb.ForbiddenAccount) string { return info.UserID })
 	userMap, err := o.Chat.MapUserFullInfo(ctx, userIDs)
 	if err != nil {
 		return nil, err

--- a/internal/rpc/admin/user_ip_limit_login.go
+++ b/internal/rpc/admin/user_ip_limit_login.go
@@ -16,10 +16,11 @@ package admin
 
 import (
 	"context"
-	"github.com/openimsdk/tools/utils/datautil"
 	"time"
 
-	admin2 "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	"github.com/openimsdk/tools/utils/datautil"
+
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
 	"github.com/openimsdk/tools/errs"
@@ -33,7 +34,7 @@ func (o *adminServer) SearchUserIPLimitLogin(ctx context.Context, req *admin.Sea
 	if err != nil {
 		return nil, err
 	}
-	userIDs := datautil.Slice(list, func(info *admin2.LimitUserLoginIP) string { return info.UserID })
+	userIDs := datautil.Slice(list, func(info *admindb.LimitUserLoginIP) string { return info.UserID })
 	userMap, err := o.Chat.MapUserPublicInfo(ctx, datautil.Distinct(userIDs))
 	if err != nil {
 		return nil, err
@@ -58,9 +59,9 @@ func (o *adminServer) AddUserIPLimitLogin(ctx context.Context, req *admin.AddUse
 		return nil, errs.ErrArgs.WrapMsg("limits is empty")
 	}
 	now := time.Now()
-	ts := make([]*admin2.LimitUserLoginIP, 0, len(req.Limits))
+	ts := make([]*admindb.LimitUserLoginIP, 0, len(req.Limits))
 	for _, limit := range req.Limits {
-		ts = append(ts, &admin2.LimitUserLoginIP{
+		ts = append(ts, &admindb.LimitUserLoginIP{
 			UserID:     limit.UserID,
 			IP:         limit.Ip,
 			CreateTime: now,
@@ -79,12 +80,12 @@ func (o *adminServer) DelUserIPLimitLogin(ctx context.Context, req *admin.DelUse
 	if len(req.Limits) == 0 {
 		return nil, errs.ErrArgs.WrapMsg("limits is empty")
 	}
-	ts := make([]*admin2.LimitUserLoginIP, 0, len(req.Limits))
+	ts := make([]*admindb.LimitUserLoginIP, 0, len(req.Limits))
 	for _, limit := range req.Limits {
 		if limit.UserID == "" || limit.Ip == "" {
 			return nil, errs.ErrArgs.WrapMsg("user_id or ip is empty")
 		}
-		ts = append(ts, &admin2.LimitUserLoginIP{
+		ts = append(ts, &admindb.LimitUserLoginIP{
 			UserID: limit.UserID,
 			IP:     limit.Ip,
 		})

--- a/internal/rpc/chat/callback.go
+++ b/internal/rpc/chat/callback.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	constant2 "github.com/openimsdk/chat/pkg/common/constant"
+	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/eerrs"
 	"github.com/openimsdk/chat/pkg/protocol/chat"
-	"github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/errs"
 )
 
@@ -42,7 +42,7 @@ func (c CallbackCommand) GetCallbackCommand() string {
 
 func (o *chatSvr) OpenIMCallback(ctx context.Context, req *chat.OpenIMCallbackReq) (*chat.OpenIMCallbackResp, error) {
 	switch req.Command {
-	case constant.CallbackBeforeAddFriendCommand:
+	case constantpb.CallbackBeforeAddFriendCommand:
 		var data CallbackBeforeAddFriendReq
 		if err := json.Unmarshal([]byte(req.Body), &data); err != nil {
 			return nil, errs.Wrap(err)
@@ -51,7 +51,7 @@ func (o *chatSvr) OpenIMCallback(ctx context.Context, req *chat.OpenIMCallbackRe
 		if err != nil {
 			return nil, err
 		}
-		if user.AllowAddFriend != constant2.OrdinaryUserAddFriendEnable {
+		if user.AllowAddFriend != constant.OrdinaryUserAddFriendEnable {
 			return nil, eerrs.ErrRefuseFriend.WrapMsg(fmt.Sprintf("state %d", user.AllowAddFriend))
 		}
 		return &chat.OpenIMCallbackResp{}, nil

--- a/internal/rpc/chat/password.go
+++ b/internal/rpc/chat/password.go
@@ -16,6 +16,7 @@ package chat
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/errs"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
@@ -51,10 +52,9 @@ func (o *chatSvr) ResetPassword(ctx context.Context, req *chat.ResetPasswordReq)
 			return nil, err
 		}
 		err = o.Database.UpdatePasswordAndDeleteVerifyCode(ctx, attribute.UserID, req.Password, verifyCodeID)
-	}
-
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &chat.ResetPasswordResp{}, nil
 }

--- a/internal/rpc/chat/rtc.go
+++ b/internal/rpc/chat/rtc.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/protocol/chat"
 )

--- a/internal/rpc/chat/start.go
+++ b/internal/rpc/chat/start.go
@@ -2,6 +2,8 @@ package chat
 
 import (
 	"context"
+	"time"
+
 	"github.com/openimsdk/chat/pkg/common/mctx"
 	"github.com/openimsdk/chat/pkg/common/rtc"
 	"github.com/openimsdk/chat/pkg/protocol/admin"
@@ -12,7 +14,6 @@ import (
 	"github.com/openimsdk/tools/mw"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"time"
 
 	"github.com/openimsdk/chat/pkg/common/config"
 	"github.com/openimsdk/chat/pkg/common/db/database"

--- a/internal/rpc/chat/user.go
+++ b/internal/rpc/chat/user.go
@@ -16,11 +16,12 @@ package chat
 
 import (
 	"context"
-	"github.com/openimsdk/chat/pkg/common/db/dbutil"
-	chat2 "github.com/openimsdk/chat/pkg/common/db/table/chat"
-	constant2 "github.com/openimsdk/protocol/constant"
-	"github.com/openimsdk/tools/mcontext"
 	"time"
+
+	"github.com/openimsdk/chat/pkg/common/db/dbutil"
+	chatdb "github.com/openimsdk/chat/pkg/common/db/table/chat"
+	constantpb "github.com/openimsdk/protocol/constant"
+	"github.com/openimsdk/tools/mcontext"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
 	"github.com/openimsdk/chat/pkg/common/mctx"
@@ -142,23 +143,23 @@ func (o *chatSvr) AddUserAccount(ctx context.Context, req *chat.AddUserAccountRe
 		}
 	}
 
-	register := &chat2.Register{
+	register := &chatdb.Register{
 		UserID:      req.User.UserID,
 		DeviceID:    req.DeviceID,
 		IP:          req.Ip,
-		Platform:    constant2.PlatformID2Name[int(req.Platform)],
+		Platform:    constantpb.PlatformID2Name[int(req.Platform)],
 		AccountType: "",
 		Mode:        constant.UserMode,
 		CreateTime:  time.Now(),
 	}
-	account := &chat2.Account{
+	account := &chatdb.Account{
 		UserID:         req.User.UserID,
 		Password:       req.User.Password,
 		OperatorUserID: mcontext.GetOpUserID(ctx),
 		ChangeTime:     register.CreateTime,
 		CreateTime:     register.CreateTime,
 	}
-	attribute := &chat2.Attribute{
+	attribute := &chatdb.Attribute{
 		UserID:         req.User.UserID,
 		Account:        req.User.Account,
 		PhoneNumber:    req.User.PhoneNumber,

--- a/pkg/common/db/database/admin.go
+++ b/pkg/common/db/database/admin.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"context"
+
 	"github.com/openimsdk/chat/pkg/common/db/cache"
 	"github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/db/mongoutil"
@@ -24,55 +25,55 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/openimsdk/chat/pkg/common/db/model/admin"
-	table "github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 )
 
 type AdminDatabaseInterface interface {
-	GetAdmin(ctx context.Context, account string) (*table.Admin, error)
-	GetAdminUserID(ctx context.Context, userID string) (*table.Admin, error)
+	GetAdmin(ctx context.Context, account string) (*admindb.Admin, error)
+	GetAdminUserID(ctx context.Context, userID string) (*admindb.Admin, error)
 	UpdateAdmin(ctx context.Context, userID string, update map[string]any) error
 	ChangePassword(ctx context.Context, userID string, newPassword string) error
-	AddAdminAccount(ctx context.Context, admin []*table.Admin) error
+	AddAdminAccount(ctx context.Context, admin []*admindb.Admin) error
 	DelAdminAccount(ctx context.Context, userIDs []string) error
-	SearchAdminAccount(ctx context.Context, pagination pagination.Pagination) (int64, []*table.Admin, error)
-	CreateApplet(ctx context.Context, applets []*table.Applet) error
+	SearchAdminAccount(ctx context.Context, pagination pagination.Pagination) (int64, []*admindb.Admin, error)
+	CreateApplet(ctx context.Context, applets []*admindb.Applet) error
 	DelApplet(ctx context.Context, appletIDs []string) error
-	GetApplet(ctx context.Context, appletID string) (*table.Applet, error)
-	FindApplet(ctx context.Context, appletIDs []string) ([]*table.Applet, error)
-	SearchApplet(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.Applet, error)
-	FindOnShelf(ctx context.Context) ([]*table.Applet, error)
+	GetApplet(ctx context.Context, appletID string) (*admindb.Applet, error)
+	FindApplet(ctx context.Context, appletIDs []string) ([]*admindb.Applet, error)
+	SearchApplet(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.Applet, error)
+	FindOnShelf(ctx context.Context) ([]*admindb.Applet, error)
 	UpdateApplet(ctx context.Context, appletID string, update map[string]any) error
 	GetConfig(ctx context.Context) (map[string]string, error)
 	SetConfig(ctx context.Context, cs map[string]string) error
 	DelConfig(ctx context.Context, keys []string) error
-	FindInvitationRegister(ctx context.Context, codes []string) ([]*table.InvitationRegister, error)
+	FindInvitationRegister(ctx context.Context, codes []string) ([]*admindb.InvitationRegister, error)
 	DelInvitationRegister(ctx context.Context, codes []string) error
 	UpdateInvitationRegister(ctx context.Context, code string, fields map[string]any) error
-	CreatInvitationRegister(ctx context.Context, invitationRegisters []*table.InvitationRegister) error
-	SearchInvitationRegister(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*table.InvitationRegister, error)
-	SearchIPForbidden(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*table.IPForbidden, error)
-	AddIPForbidden(ctx context.Context, ms []*table.IPForbidden) error
-	FindIPForbidden(ctx context.Context, ms []string) ([]*table.IPForbidden, error)
+	CreatInvitationRegister(ctx context.Context, invitationRegisters []*admindb.InvitationRegister) error
+	SearchInvitationRegister(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*admindb.InvitationRegister, error)
+	SearchIPForbidden(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*admindb.IPForbidden, error)
+	AddIPForbidden(ctx context.Context, ms []*admindb.IPForbidden) error
+	FindIPForbidden(ctx context.Context, ms []string) ([]*admindb.IPForbidden, error)
 	DelIPForbidden(ctx context.Context, ips []string) error
 	FindDefaultFriend(ctx context.Context, userIDs []string) ([]string, error)
-	AddDefaultFriend(ctx context.Context, ms []*table.RegisterAddFriend) error
+	AddDefaultFriend(ctx context.Context, ms []*admindb.RegisterAddFriend) error
 	DelDefaultFriend(ctx context.Context, userIDs []string) error
-	SearchDefaultFriend(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.RegisterAddFriend, error)
+	SearchDefaultFriend(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.RegisterAddFriend, error)
 	FindDefaultGroup(ctx context.Context, groupIDs []string) ([]string, error)
-	AddDefaultGroup(ctx context.Context, ms []*table.RegisterAddGroup) error
+	AddDefaultGroup(ctx context.Context, ms []*admindb.RegisterAddGroup) error
 	DelDefaultGroup(ctx context.Context, groupIDs []string) error
-	SearchDefaultGroup(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.RegisterAddGroup, error)
-	FindBlockInfo(ctx context.Context, userIDs []string) ([]*table.ForbiddenAccount, error)
-	GetBlockInfo(ctx context.Context, userID string) (*table.ForbiddenAccount, error)
-	BlockUser(ctx context.Context, f []*table.ForbiddenAccount) error
+	SearchDefaultGroup(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.RegisterAddGroup, error)
+	FindBlockInfo(ctx context.Context, userIDs []string) ([]*admindb.ForbiddenAccount, error)
+	GetBlockInfo(ctx context.Context, userID string) (*admindb.ForbiddenAccount, error)
+	BlockUser(ctx context.Context, f []*admindb.ForbiddenAccount) error
 	DelBlockUser(ctx context.Context, userID []string) error
-	SearchBlockUser(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.ForbiddenAccount, error)
-	FindBlockUser(ctx context.Context, userIDs []string) ([]*table.ForbiddenAccount, error)
-	SearchUserLimitLogin(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.LimitUserLoginIP, error)
-	AddUserLimitLogin(ctx context.Context, ms []*table.LimitUserLoginIP) error
-	DelUserLimitLogin(ctx context.Context, ms []*table.LimitUserLoginIP) error
+	SearchBlockUser(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.ForbiddenAccount, error)
+	FindBlockUser(ctx context.Context, userIDs []string) ([]*admindb.ForbiddenAccount, error)
+	SearchUserLimitLogin(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.LimitUserLoginIP, error)
+	AddUserLimitLogin(ctx context.Context, ms []*admindb.LimitUserLoginIP) error
+	DelUserLimitLogin(ctx context.Context, ms []*admindb.LimitUserLoginIP) error
 	CountLimitUserLoginIP(ctx context.Context, userID string) (uint32, error)
-	GetLimitUserLoginIP(ctx context.Context, userID string, ip string) (*table.LimitUserLoginIP, error)
+	GetLimitUserLoginIP(ctx context.Context, userID string, ip string) (*admindb.LimitUserLoginIP, error)
 	CacheToken(ctx context.Context, userID string, token string) error
 	GetTokens(ctx context.Context, userID string) (map[string]int32, error)
 }
@@ -131,23 +132,23 @@ func NewAdminDatabase(cli *mongoutil.Client, rdb redis.UniversalClient) (AdminDa
 
 type AdminDatabase struct {
 	tx                 tx.Tx
-	admin              table.AdminInterface
-	ipForbidden        table.IPForbiddenInterface
-	forbiddenAccount   table.ForbiddenAccountInterface
-	limitUserLoginIP   table.LimitUserLoginIPInterface
-	invitationRegister table.InvitationRegisterInterface
-	registerAddFriend  table.RegisterAddFriendInterface
-	registerAddGroup   table.RegisterAddGroupInterface
-	applet             table.AppletInterface
-	clientConfig       table.ClientConfigInterface
+	admin              admindb.AdminInterface
+	ipForbidden        admindb.IPForbiddenInterface
+	forbiddenAccount   admindb.ForbiddenAccountInterface
+	limitUserLoginIP   admindb.LimitUserLoginIPInterface
+	invitationRegister admindb.InvitationRegisterInterface
+	registerAddFriend  admindb.RegisterAddFriendInterface
+	registerAddGroup   admindb.RegisterAddGroupInterface
+	applet             admindb.AppletInterface
+	clientConfig       admindb.ClientConfigInterface
 	cache              cache.TokenInterface
 }
 
-func (o *AdminDatabase) GetAdmin(ctx context.Context, account string) (*table.Admin, error) {
+func (o *AdminDatabase) GetAdmin(ctx context.Context, account string) (*admindb.Admin, error) {
 	return o.admin.Take(ctx, account)
 }
 
-func (o *AdminDatabase) GetAdminUserID(ctx context.Context, userID string) (*table.Admin, error) {
+func (o *AdminDatabase) GetAdminUserID(ctx context.Context, userID string) (*admindb.Admin, error) {
 	return o.admin.TakeUserID(ctx, userID)
 }
 
@@ -158,7 +159,8 @@ func (o *AdminDatabase) UpdateAdmin(ctx context.Context, userID string, update m
 func (o *AdminDatabase) ChangePassword(ctx context.Context, userID string, newPassword string) error {
 	return o.admin.ChangePassword(ctx, userID, newPassword)
 }
-func (o *AdminDatabase) AddAdminAccount(ctx context.Context, admins []*table.Admin) error {
+
+func (o *AdminDatabase) AddAdminAccount(ctx context.Context, admins []*admindb.Admin) error {
 	return o.admin.Create(ctx, admins)
 }
 
@@ -166,11 +168,11 @@ func (o *AdminDatabase) DelAdminAccount(ctx context.Context, userIDs []string) e
 	return o.admin.Delete(ctx, userIDs)
 }
 
-func (o *AdminDatabase) SearchAdminAccount(ctx context.Context, pagination pagination.Pagination) (int64, []*table.Admin, error) {
+func (o *AdminDatabase) SearchAdminAccount(ctx context.Context, pagination pagination.Pagination) (int64, []*admindb.Admin, error) {
 	return o.admin.Search(ctx, pagination)
 }
 
-func (o *AdminDatabase) CreateApplet(ctx context.Context, applets []*table.Applet) error {
+func (o *AdminDatabase) CreateApplet(ctx context.Context, applets []*admindb.Applet) error {
 	return o.applet.Create(ctx, applets)
 }
 
@@ -178,19 +180,19 @@ func (o *AdminDatabase) DelApplet(ctx context.Context, appletIDs []string) error
 	return o.applet.Del(ctx, appletIDs)
 }
 
-func (o *AdminDatabase) GetApplet(ctx context.Context, appletID string) (*table.Applet, error) {
+func (o *AdminDatabase) GetApplet(ctx context.Context, appletID string) (*admindb.Applet, error) {
 	return o.applet.Take(ctx, appletID)
 }
 
-func (o *AdminDatabase) FindApplet(ctx context.Context, appletIDs []string) ([]*table.Applet, error) {
+func (o *AdminDatabase) FindApplet(ctx context.Context, appletIDs []string) ([]*admindb.Applet, error) {
 	return o.applet.FindID(ctx, appletIDs)
 }
 
-func (o *AdminDatabase) SearchApplet(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.Applet, error) {
+func (o *AdminDatabase) SearchApplet(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.Applet, error) {
 	return o.applet.Search(ctx, keyword, pagination)
 }
 
-func (o *AdminDatabase) FindOnShelf(ctx context.Context) ([]*table.Applet, error) {
+func (o *AdminDatabase) FindOnShelf(ctx context.Context) ([]*admindb.Applet, error) {
 	return o.applet.FindOnShelf(ctx)
 }
 
@@ -210,7 +212,7 @@ func (o *AdminDatabase) DelConfig(ctx context.Context, keys []string) error {
 	return o.clientConfig.Del(ctx, keys)
 }
 
-func (o *AdminDatabase) FindInvitationRegister(ctx context.Context, codes []string) ([]*table.InvitationRegister, error) {
+func (o *AdminDatabase) FindInvitationRegister(ctx context.Context, codes []string) ([]*admindb.InvitationRegister, error) {
 	return o.invitationRegister.Find(ctx, codes)
 }
 
@@ -222,23 +224,23 @@ func (o *AdminDatabase) UpdateInvitationRegister(ctx context.Context, code strin
 	return o.invitationRegister.Update(ctx, code, fields)
 }
 
-func (o *AdminDatabase) CreatInvitationRegister(ctx context.Context, invitationRegisters []*table.InvitationRegister) error {
+func (o *AdminDatabase) CreatInvitationRegister(ctx context.Context, invitationRegisters []*admindb.InvitationRegister) error {
 	return o.invitationRegister.Create(ctx, invitationRegisters)
 }
 
-func (o *AdminDatabase) SearchInvitationRegister(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*table.InvitationRegister, error) {
+func (o *AdminDatabase) SearchInvitationRegister(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*admindb.InvitationRegister, error) {
 	return o.invitationRegister.Search(ctx, keyword, state, userIDs, codes, pagination)
 }
 
-func (o *AdminDatabase) SearchIPForbidden(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*table.IPForbidden, error) {
+func (o *AdminDatabase) SearchIPForbidden(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*admindb.IPForbidden, error) {
 	return o.ipForbidden.Search(ctx, keyword, state, pagination)
 }
 
-func (o *AdminDatabase) AddIPForbidden(ctx context.Context, ms []*table.IPForbidden) error {
+func (o *AdminDatabase) AddIPForbidden(ctx context.Context, ms []*admindb.IPForbidden) error {
 	return o.ipForbidden.Create(ctx, ms)
 }
 
-func (o *AdminDatabase) FindIPForbidden(ctx context.Context, ms []string) ([]*table.IPForbidden, error) {
+func (o *AdminDatabase) FindIPForbidden(ctx context.Context, ms []string) ([]*admindb.IPForbidden, error) {
 	return o.ipForbidden.Find(ctx, ms)
 }
 
@@ -250,7 +252,7 @@ func (o *AdminDatabase) FindDefaultFriend(ctx context.Context, userIDs []string)
 	return o.registerAddFriend.FindUserID(ctx, userIDs)
 }
 
-func (o *AdminDatabase) AddDefaultFriend(ctx context.Context, ms []*table.RegisterAddFriend) error {
+func (o *AdminDatabase) AddDefaultFriend(ctx context.Context, ms []*admindb.RegisterAddFriend) error {
 	return o.registerAddFriend.Add(ctx, ms)
 }
 
@@ -258,7 +260,7 @@ func (o *AdminDatabase) DelDefaultFriend(ctx context.Context, userIDs []string) 
 	return o.registerAddFriend.Del(ctx, userIDs)
 }
 
-func (o *AdminDatabase) SearchDefaultFriend(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.RegisterAddFriend, error) {
+func (o *AdminDatabase) SearchDefaultFriend(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.RegisterAddFriend, error) {
 	return o.registerAddFriend.Search(ctx, keyword, pagination)
 }
 
@@ -266,7 +268,7 @@ func (o *AdminDatabase) FindDefaultGroup(ctx context.Context, groupIDs []string)
 	return o.registerAddGroup.FindGroupID(ctx, groupIDs)
 }
 
-func (o *AdminDatabase) AddDefaultGroup(ctx context.Context, ms []*table.RegisterAddGroup) error {
+func (o *AdminDatabase) AddDefaultGroup(ctx context.Context, ms []*admindb.RegisterAddGroup) error {
 	return o.registerAddGroup.Add(ctx, ms)
 }
 
@@ -274,19 +276,19 @@ func (o *AdminDatabase) DelDefaultGroup(ctx context.Context, groupIDs []string) 
 	return o.registerAddGroup.Del(ctx, groupIDs)
 }
 
-func (o *AdminDatabase) SearchDefaultGroup(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.RegisterAddGroup, error) {
+func (o *AdminDatabase) SearchDefaultGroup(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.RegisterAddGroup, error) {
 	return o.registerAddGroup.Search(ctx, keyword, pagination)
 }
 
-func (o *AdminDatabase) FindBlockInfo(ctx context.Context, userIDs []string) ([]*table.ForbiddenAccount, error) {
+func (o *AdminDatabase) FindBlockInfo(ctx context.Context, userIDs []string) ([]*admindb.ForbiddenAccount, error) {
 	return o.forbiddenAccount.Find(ctx, userIDs)
 }
 
-func (o *AdminDatabase) GetBlockInfo(ctx context.Context, userID string) (*table.ForbiddenAccount, error) {
+func (o *AdminDatabase) GetBlockInfo(ctx context.Context, userID string) (*admindb.ForbiddenAccount, error) {
 	return o.forbiddenAccount.Take(ctx, userID)
 }
 
-func (o *AdminDatabase) BlockUser(ctx context.Context, f []*table.ForbiddenAccount) error {
+func (o *AdminDatabase) BlockUser(ctx context.Context, f []*admindb.ForbiddenAccount) error {
 	return o.forbiddenAccount.Create(ctx, f)
 }
 
@@ -294,23 +296,23 @@ func (o *AdminDatabase) DelBlockUser(ctx context.Context, userID []string) error
 	return o.forbiddenAccount.Delete(ctx, userID)
 }
 
-func (o *AdminDatabase) SearchBlockUser(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.ForbiddenAccount, error) {
+func (o *AdminDatabase) SearchBlockUser(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.ForbiddenAccount, error) {
 	return o.forbiddenAccount.Search(ctx, keyword, pagination)
 }
 
-func (o *AdminDatabase) FindBlockUser(ctx context.Context, userIDs []string) ([]*table.ForbiddenAccount, error) {
+func (o *AdminDatabase) FindBlockUser(ctx context.Context, userIDs []string) ([]*admindb.ForbiddenAccount, error) {
 	return o.forbiddenAccount.Find(ctx, userIDs)
 }
 
-func (o *AdminDatabase) SearchUserLimitLogin(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*table.LimitUserLoginIP, error) {
+func (o *AdminDatabase) SearchUserLimitLogin(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admindb.LimitUserLoginIP, error) {
 	return o.limitUserLoginIP.Search(ctx, keyword, pagination)
 }
 
-func (o *AdminDatabase) AddUserLimitLogin(ctx context.Context, ms []*table.LimitUserLoginIP) error {
+func (o *AdminDatabase) AddUserLimitLogin(ctx context.Context, ms []*admindb.LimitUserLoginIP) error {
 	return o.limitUserLoginIP.Create(ctx, ms)
 }
 
-func (o *AdminDatabase) DelUserLimitLogin(ctx context.Context, ms []*table.LimitUserLoginIP) error {
+func (o *AdminDatabase) DelUserLimitLogin(ctx context.Context, ms []*admindb.LimitUserLoginIP) error {
 	return o.limitUserLoginIP.Delete(ctx, ms)
 }
 
@@ -318,7 +320,7 @@ func (o *AdminDatabase) CountLimitUserLoginIP(ctx context.Context, userID string
 	return o.limitUserLoginIP.Count(ctx, userID)
 }
 
-func (o *AdminDatabase) GetLimitUserLoginIP(ctx context.Context, userID string, ip string) (*table.LimitUserLoginIP, error) {
+func (o *AdminDatabase) GetLimitUserLoginIP(ctx context.Context, userID string, ip string) (*admindb.LimitUserLoginIP, error) {
 	return o.limitUserLoginIP.Take(ctx, userID, ip)
 }
 

--- a/pkg/common/db/database/chat.go
+++ b/pkg/common/db/database/chat.go
@@ -16,41 +16,42 @@ package database
 
 import (
 	"context"
+	"time"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"github.com/openimsdk/tools/db/tx"
-	"time"
 
-	constant2 "github.com/openimsdk/chat/pkg/common/constant"
-	admin2 "github.com/openimsdk/chat/pkg/common/db/model/admin"
+	"github.com/openimsdk/chat/pkg/common/constant"
+	admindb "github.com/openimsdk/chat/pkg/common/db/model/admin"
 	"github.com/openimsdk/chat/pkg/common/db/model/chat"
 	"github.com/openimsdk/chat/pkg/common/db/table/admin"
-	table "github.com/openimsdk/chat/pkg/common/db/table/chat"
+	chatdb "github.com/openimsdk/chat/pkg/common/db/table/chat"
 )
 
 type ChatDatabaseInterface interface {
-	GetUser(ctx context.Context, userID string) (account *table.Account, err error)
+	GetUser(ctx context.Context, userID string) (account *chatdb.Account, err error)
 	UpdateUseInfo(ctx context.Context, userID string, attribute map[string]any) (err error)
-	FindAttribute(ctx context.Context, userIDs []string) ([]*table.Attribute, error)
-	FindAttributeByAccount(ctx context.Context, accounts []string) ([]*table.Attribute, error)
-	TakeAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*table.Attribute, error)
-	TakeAttributeByEmail(ctx context.Context, Email string) (*table.Attribute, error)
-	TakeAttributeByAccount(ctx context.Context, account string) (*table.Attribute, error)
-	TakeAttributeByUserID(ctx context.Context, userID string) (*table.Attribute, error)
-	Search(ctx context.Context, normalUser int32, keyword string, gender int32, pagination pagination.Pagination) (int64, []*table.Attribute, error)
-	SearchUser(ctx context.Context, keyword string, userIDs []string, genders []int32, pagination pagination.Pagination) (int64, []*table.Attribute, error)
+	FindAttribute(ctx context.Context, userIDs []string) ([]*chatdb.Attribute, error)
+	FindAttributeByAccount(ctx context.Context, accounts []string) ([]*chatdb.Attribute, error)
+	TakeAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*chatdb.Attribute, error)
+	TakeAttributeByEmail(ctx context.Context, Email string) (*chatdb.Attribute, error)
+	TakeAttributeByAccount(ctx context.Context, account string) (*chatdb.Attribute, error)
+	TakeAttributeByUserID(ctx context.Context, userID string) (*chatdb.Attribute, error)
+	Search(ctx context.Context, normalUser int32, keyword string, gender int32, pagination pagination.Pagination) (int64, []*chatdb.Attribute, error)
+	SearchUser(ctx context.Context, keyword string, userIDs []string, genders []int32, pagination pagination.Pagination) (int64, []*chatdb.Attribute, error)
 	CountVerifyCodeRange(ctx context.Context, account string, start time.Time, end time.Time) (int64, error)
-	AddVerifyCode(ctx context.Context, verifyCode *table.VerifyCode, fn func() error) error
+	AddVerifyCode(ctx context.Context, verifyCode *chatdb.VerifyCode, fn func() error) error
 	UpdateVerifyCodeIncrCount(ctx context.Context, id string) error
-	TakeLastVerifyCode(ctx context.Context, account string) (*table.VerifyCode, error)
+	TakeLastVerifyCode(ctx context.Context, account string) (*chatdb.VerifyCode, error)
 	DelVerifyCode(ctx context.Context, id string) error
-	RegisterUser(ctx context.Context, register *table.Register, account *table.Account, attribute *table.Attribute) error
-	GetAccount(ctx context.Context, userID string) (*table.Account, error)
-	GetAttribute(ctx context.Context, userID string) (*table.Attribute, error)
-	GetAttributeByAccount(ctx context.Context, account string) (*table.Attribute, error)
-	GetAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*table.Attribute, error)
-	GetAttributeByEmail(ctx context.Context, email string) (*table.Attribute, error)
-	LoginRecord(ctx context.Context, record *table.UserLoginRecord, verifyCodeID *string) error
+	RegisterUser(ctx context.Context, register *chatdb.Register, account *chatdb.Account, attribute *chatdb.Attribute) error
+	GetAccount(ctx context.Context, userID string) (*chatdb.Account, error)
+	GetAttribute(ctx context.Context, userID string) (*chatdb.Attribute, error)
+	GetAttributeByAccount(ctx context.Context, account string) (*chatdb.Attribute, error)
+	GetAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*chatdb.Attribute, error)
+	GetAttributeByEmail(ctx context.Context, email string) (*chatdb.Attribute, error)
+	LoginRecord(ctx context.Context, record *chatdb.UserLoginRecord, verifyCodeID *string) error
 	UpdatePassword(ctx context.Context, userID string, password string) error
 	UpdatePasswordAndDeleteVerifyCode(ctx context.Context, userID string, password string, codeID string) error
 	NewUserCountTotal(ctx context.Context, before *time.Time) (int64, error)
@@ -79,7 +80,7 @@ func NewChatDatabase(cli *mongoutil.Client) (ChatDatabaseInterface, error) {
 	if err != nil {
 		return nil, err
 	}
-	forbiddenAccount, err := admin2.NewForbiddenAccount(cli.GetDB())
+	forbiddenAccount, err := admindb.NewForbiddenAccount(cli.GetDB())
 	if err != nil {
 		return nil, err
 	}
@@ -96,15 +97,15 @@ func NewChatDatabase(cli *mongoutil.Client) (ChatDatabaseInterface, error) {
 
 type ChatDatabase struct {
 	tx               tx.Tx
-	register         table.RegisterInterface
-	account          table.AccountInterface
-	attribute        table.AttributeInterface
-	userLoginRecord  table.UserLoginRecordInterface
-	verifyCode       table.VerifyCodeInterface
+	register         chatdb.RegisterInterface
+	account          chatdb.AccountInterface
+	attribute        chatdb.AttributeInterface
+	userLoginRecord  chatdb.UserLoginRecordInterface
+	verifyCode       chatdb.VerifyCodeInterface
 	forbiddenAccount admin.ForbiddenAccountInterface
 }
 
-func (o *ChatDatabase) GetUser(ctx context.Context, userID string) (account *table.Account, err error) {
+func (o *ChatDatabase) GetUser(ctx context.Context, userID string) (account *chatdb.Account, err error) {
 	return o.account.Take(ctx, userID)
 }
 
@@ -112,33 +113,33 @@ func (o *ChatDatabase) UpdateUseInfo(ctx context.Context, userID string, attribu
 	return o.attribute.Update(ctx, userID, attribute)
 }
 
-func (o *ChatDatabase) FindAttribute(ctx context.Context, userIDs []string) ([]*table.Attribute, error) {
+func (o *ChatDatabase) FindAttribute(ctx context.Context, userIDs []string) ([]*chatdb.Attribute, error) {
 	return o.attribute.Find(ctx, userIDs)
 }
 
-func (o *ChatDatabase) FindAttributeByAccount(ctx context.Context, accounts []string) ([]*table.Attribute, error) {
+func (o *ChatDatabase) FindAttributeByAccount(ctx context.Context, accounts []string) ([]*chatdb.Attribute, error) {
 	return o.attribute.FindAccount(ctx, accounts)
 }
 
-func (o *ChatDatabase) TakeAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*table.Attribute, error) {
+func (o *ChatDatabase) TakeAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*chatdb.Attribute, error) {
 	return o.attribute.TakePhone(ctx, areaCode, phoneNumber)
 }
 
-func (o *ChatDatabase) TakeAttributeByEmail(ctx context.Context, email string) (*table.Attribute, error) {
+func (o *ChatDatabase) TakeAttributeByEmail(ctx context.Context, email string) (*chatdb.Attribute, error) {
 	return o.attribute.TakeEmail(ctx, email)
 }
 
-func (o *ChatDatabase) TakeAttributeByAccount(ctx context.Context, account string) (*table.Attribute, error) {
+func (o *ChatDatabase) TakeAttributeByAccount(ctx context.Context, account string) (*chatdb.Attribute, error) {
 	return o.attribute.TakeAccount(ctx, account)
 }
 
-func (o *ChatDatabase) TakeAttributeByUserID(ctx context.Context, userID string) (*table.Attribute, error) {
+func (o *ChatDatabase) TakeAttributeByUserID(ctx context.Context, userID string) (*chatdb.Attribute, error) {
 	return o.attribute.Take(ctx, userID)
 }
 
-func (o *ChatDatabase) Search(ctx context.Context, normalUser int32, keyword string, genders int32, pagination pagination.Pagination) (total int64, attributes []*table.Attribute, err error) {
+func (o *ChatDatabase) Search(ctx context.Context, normalUser int32, keyword string, genders int32, pagination pagination.Pagination) (total int64, attributes []*chatdb.Attribute, err error) {
 	var forbiddenIDs []string
-	if int(normalUser) == constant2.NormalUser {
+	if int(normalUser) == constant.NormalUser {
 		forbiddenIDs, err = o.forbiddenAccount.FindAllIDs(ctx)
 		if err != nil {
 			return 0, nil, err
@@ -151,7 +152,7 @@ func (o *ChatDatabase) Search(ctx context.Context, normalUser int32, keyword str
 	return total, totalUser, nil
 }
 
-func (o *ChatDatabase) SearchUser(ctx context.Context, keyword string, userIDs []string, genders []int32, pagination pagination.Pagination) (int64, []*table.Attribute, error) {
+func (o *ChatDatabase) SearchUser(ctx context.Context, keyword string, userIDs []string, genders []int32, pagination pagination.Pagination) (int64, []*chatdb.Attribute, error) {
 	return o.attribute.SearchUser(ctx, keyword, userIDs, genders, pagination)
 }
 
@@ -159,9 +160,9 @@ func (o *ChatDatabase) CountVerifyCodeRange(ctx context.Context, account string,
 	return o.verifyCode.RangeNum(ctx, account, start, end)
 }
 
-func (o *ChatDatabase) AddVerifyCode(ctx context.Context, verifyCode *table.VerifyCode, fn func() error) error {
+func (o *ChatDatabase) AddVerifyCode(ctx context.Context, verifyCode *chatdb.VerifyCode, fn func() error) error {
 	return o.tx.Transaction(ctx, func(ctx context.Context) error {
-		if err := o.verifyCode.Add(ctx, []*table.VerifyCode{verifyCode}); err != nil {
+		if err := o.verifyCode.Add(ctx, []*chatdb.VerifyCode{verifyCode}); err != nil {
 			return err
 		}
 		if fn != nil {
@@ -175,7 +176,7 @@ func (o *ChatDatabase) UpdateVerifyCodeIncrCount(ctx context.Context, id string)
 	return o.verifyCode.Incr(ctx, id)
 }
 
-func (o *ChatDatabase) TakeLastVerifyCode(ctx context.Context, account string) (*table.VerifyCode, error) {
+func (o *ChatDatabase) TakeLastVerifyCode(ctx context.Context, account string) (*chatdb.VerifyCode, error) {
 	return o.verifyCode.TakeLast(ctx, account)
 }
 
@@ -183,7 +184,7 @@ func (o *ChatDatabase) DelVerifyCode(ctx context.Context, id string) error {
 	return o.verifyCode.Delete(ctx, id)
 }
 
-func (o *ChatDatabase) RegisterUser(ctx context.Context, register *table.Register, account *table.Account, attribute *table.Attribute) error {
+func (o *ChatDatabase) RegisterUser(ctx context.Context, register *chatdb.Register, account *chatdb.Account, attribute *chatdb.Attribute) error {
 	return o.tx.Transaction(ctx, func(ctx context.Context) error {
 		if err := o.register.Create(ctx, register); err != nil {
 			return err
@@ -198,25 +199,27 @@ func (o *ChatDatabase) RegisterUser(ctx context.Context, register *table.Registe
 	})
 }
 
-func (o *ChatDatabase) GetAccount(ctx context.Context, userID string) (*table.Account, error) {
+func (o *ChatDatabase) GetAccount(ctx context.Context, userID string) (*chatdb.Account, error) {
 	return o.account.Take(ctx, userID)
 }
 
-func (o *ChatDatabase) GetAttribute(ctx context.Context, userID string) (*table.Attribute, error) {
+func (o *ChatDatabase) GetAttribute(ctx context.Context, userID string) (*chatdb.Attribute, error) {
 	return o.attribute.Take(ctx, userID)
 }
 
-func (o *ChatDatabase) GetAttributeByAccount(ctx context.Context, account string) (*table.Attribute, error) {
+func (o *ChatDatabase) GetAttributeByAccount(ctx context.Context, account string) (*chatdb.Attribute, error) {
 	return o.attribute.TakeAccount(ctx, account)
 }
 
-func (o *ChatDatabase) GetAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*table.Attribute, error) {
+func (o *ChatDatabase) GetAttributeByPhone(ctx context.Context, areaCode string, phoneNumber string) (*chatdb.Attribute, error) {
 	return o.attribute.TakePhone(ctx, areaCode, phoneNumber)
 }
-func (o *ChatDatabase) GetAttributeByEmail(ctx context.Context, email string) (*table.Attribute, error) {
+
+func (o *ChatDatabase) GetAttributeByEmail(ctx context.Context, email string) (*chatdb.Attribute, error) {
 	return o.attribute.TakeEmail(ctx, email)
 }
-func (o *ChatDatabase) LoginRecord(ctx context.Context, record *table.UserLoginRecord, verifyCodeID *string) error {
+
+func (o *ChatDatabase) LoginRecord(ctx context.Context, record *chatdb.UserLoginRecord, verifyCodeID *string) error {
 	return o.tx.Transaction(ctx, func(ctx context.Context) error {
 		if err := o.userLoginRecord.Create(ctx, record); err != nil {
 			return err

--- a/pkg/common/db/model/admin/admin.go
+++ b/pkg/common/db/model/admin/admin.go
@@ -16,8 +16,9 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/chat/pkg/common/constant"
-	"github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"github.com/openimsdk/tools/errs"
@@ -26,7 +27,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func NewAdmin(db *mongo.Database) (admin.AdminInterface, error) {
+func NewAdmin(db *mongo.Database) (admindb.AdminInterface, error) {
 	coll := db.Collection("admin")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: bson.D{
@@ -46,12 +47,12 @@ type Admin struct {
 	coll *mongo.Collection
 }
 
-func (o *Admin) Take(ctx context.Context, account string) (*admin.Admin, error) {
-	return mongoutil.FindOne[*admin.Admin](ctx, o.coll, bson.M{"account": account})
+func (o *Admin) Take(ctx context.Context, account string) (*admindb.Admin, error) {
+	return mongoutil.FindOne[*admindb.Admin](ctx, o.coll, bson.M{"account": account})
 }
 
-func (o *Admin) TakeUserID(ctx context.Context, userID string) (*admin.Admin, error) {
-	return mongoutil.FindOne[*admin.Admin](ctx, o.coll, bson.M{"user_id": userID})
+func (o *Admin) TakeUserID(ctx context.Context, userID string) (*admindb.Admin, error) {
+	return mongoutil.FindOne[*admindb.Admin](ctx, o.coll, bson.M{"user_id": userID})
 }
 
 func (o *Admin) Update(ctx context.Context, account string, update map[string]any) error {
@@ -61,13 +62,12 @@ func (o *Admin) Update(ctx context.Context, account string, update map[string]an
 	return mongoutil.UpdateOne(ctx, o.coll, bson.M{"user_id": account}, bson.M{"$set": update}, false)
 }
 
-func (o *Admin) Create(ctx context.Context, admins []*admin.Admin) error {
+func (o *Admin) Create(ctx context.Context, admins []*admindb.Admin) error {
 	return mongoutil.InsertMany(ctx, o.coll, admins)
 }
 
 func (o *Admin) ChangePassword(ctx context.Context, userID string, newPassword string) error {
 	return mongoutil.UpdateOne(ctx, o.coll, bson.M{"user_id": userID}, bson.M{"$set": bson.M{"password": newPassword}}, false)
-
 }
 
 func (o *Admin) Delete(ctx context.Context, userIDs []string) error {
@@ -77,8 +77,8 @@ func (o *Admin) Delete(ctx context.Context, userIDs []string) error {
 	return mongoutil.DeleteMany(ctx, o.coll, bson.M{"user_id": bson.M{"$in": userIDs}})
 }
 
-func (o *Admin) Search(ctx context.Context, pagination pagination.Pagination) (int64, []*admin.Admin, error) {
-	opt := options.Find().SetSort(bson.D{{"create_time", -1}})
+func (o *Admin) Search(ctx context.Context, pagination pagination.Pagination) (int64, []*admindb.Admin, error) {
+	opt := options.Find().SetSort(bson.D{{Key: "create_time", Value: -1}})
 	filter := bson.M{"level": constant.NormalAdmin}
-	return mongoutil.FindPage[*admin.Admin](ctx, o.coll, filter, pagination, opt)
+	return mongoutil.FindPage[*admindb.Admin](ctx, o.coll, filter, pagination, opt)
 }

--- a/pkg/common/db/model/admin/applet.go
+++ b/pkg/common/db/model/admin/applet.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"
@@ -67,7 +68,6 @@ func (o *Applet) Update(ctx context.Context, id string, data map[string]any) err
 
 func (o *Applet) Take(ctx context.Context, id string) (*admin.Applet, error) {
 	return mongoutil.FindOne[*admin.Applet](ctx, o.coll, bson.M{"id": id})
-
 }
 
 func (o *Applet) Search(ctx context.Context, keyword string, pagination pagination.Pagination) (int64, []*admin.Applet, error) {
@@ -88,10 +88,8 @@ func (o *Applet) Search(ctx context.Context, keyword string, pagination paginati
 
 func (o *Applet) FindOnShelf(ctx context.Context) ([]*admin.Applet, error) {
 	return mongoutil.Find[*admin.Applet](ctx, o.coll, bson.M{"status": constant.StatusOnShelf})
-
 }
 
 func (o *Applet) FindID(ctx context.Context, ids []string) ([]*admin.Applet, error) {
 	return mongoutil.Find[*admin.Applet](ctx, o.coll, bson.M{"id": bson.M{"$in": ids}})
-
 }

--- a/pkg/common/db/model/admin/client_config.go
+++ b/pkg/common/db/model/admin/client_config.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -55,7 +56,6 @@ func (o *ClientConfig) Set(ctx context.Context, config map[string]string) error 
 		if err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/pkg/common/db/model/admin/forbidden_account.go
+++ b/pkg/common/db/model/admin/forbidden_account.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"

--- a/pkg/common/db/model/admin/invitation_register.go
+++ b/pkg/common/db/model/admin/invitation_register.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,11 +24,11 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
-	"github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/tools/errs"
 )
 
-func NewInvitationRegister(db *mongo.Database) (admin.InvitationRegisterInterface, error) {
+func NewInvitationRegister(db *mongo.Database) (admindb.InvitationRegisterInterface, error) {
 	coll := db.Collection("invitation_register")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: bson.D{
@@ -47,8 +48,8 @@ type InvitationRegister struct {
 	coll *mongo.Collection
 }
 
-func (o *InvitationRegister) Find(ctx context.Context, codes []string) ([]*admin.InvitationRegister, error) {
-	return mongoutil.Find[*admin.InvitationRegister](ctx, o.coll, bson.M{"invitation_code": bson.M{"$in": codes}})
+func (o *InvitationRegister) Find(ctx context.Context, codes []string) ([]*admindb.InvitationRegister, error) {
+	return mongoutil.Find[*admindb.InvitationRegister](ctx, o.coll, bson.M{"invitation_code": bson.M{"$in": codes}})
 }
 
 func (o *InvitationRegister) Del(ctx context.Context, codes []string) error {
@@ -58,12 +59,12 @@ func (o *InvitationRegister) Del(ctx context.Context, codes []string) error {
 	return mongoutil.DeleteMany(ctx, o.coll, bson.M{"invitation_code": bson.M{"$in": codes}})
 }
 
-func (o *InvitationRegister) Create(ctx context.Context, v []*admin.InvitationRegister) error {
+func (o *InvitationRegister) Create(ctx context.Context, v []*admindb.InvitationRegister) error {
 	return mongoutil.InsertMany(ctx, o.coll, v)
 }
 
-func (o *InvitationRegister) Take(ctx context.Context, code string) (*admin.InvitationRegister, error) {
-	return mongoutil.FindOne[*admin.InvitationRegister](ctx, o.coll, bson.M{"code": code})
+func (o *InvitationRegister) Take(ctx context.Context, code string) (*admindb.InvitationRegister, error) {
+	return mongoutil.FindOne[*admindb.InvitationRegister](ctx, o.coll, bson.M{"code": code})
 }
 
 func (o *InvitationRegister) Update(ctx context.Context, code string, data map[string]any) error {
@@ -73,7 +74,7 @@ func (o *InvitationRegister) Update(ctx context.Context, code string, data map[s
 	return mongoutil.UpdateOne(ctx, o.coll, bson.M{"invitation_code": code}, bson.M{"$set": data}, false)
 }
 
-func (o *InvitationRegister) Search(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*admin.InvitationRegister, error) {
+func (o *InvitationRegister) Search(ctx context.Context, keyword string, state int32, userIDs []string, codes []string, pagination pagination.Pagination) (int64, []*admindb.InvitationRegister, error) {
 	filter := bson.M{}
 	switch state {
 	case constant.InvitationCodeUsed:
@@ -94,5 +95,5 @@ func (o *InvitationRegister) Search(ctx context.Context, keyword string, state i
 			{"user_id": bson.M{"$regex": keyword, "$options": "i"}},
 		}
 	}
-	return mongoutil.FindPage[*admin.InvitationRegister](ctx, o.coll, filter, pagination)
+	return mongoutil.FindPage[*admindb.InvitationRegister](ctx, o.coll, filter, pagination)
 }

--- a/pkg/common/db/model/admin/ip_forbidden.go
+++ b/pkg/common/db/model/admin/ip_forbidden.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,11 +24,11 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
-	"github.com/openimsdk/chat/pkg/common/db/table/admin"
+	admindb "github.com/openimsdk/chat/pkg/common/db/table/admin"
 	"github.com/openimsdk/tools/errs"
 )
 
-func NewIPForbidden(db *mongo.Database) (admin.IPForbiddenInterface, error) {
+func NewIPForbidden(db *mongo.Database) (admindb.IPForbiddenInterface, error) {
 	coll := db.Collection("ip_forbidden")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: bson.D{
@@ -47,17 +48,15 @@ type IPForbidden struct {
 	coll *mongo.Collection
 }
 
-func (o *IPForbidden) Take(ctx context.Context, ip string) (*admin.IPForbidden, error) {
-	return mongoutil.FindOne[*admin.IPForbidden](ctx, o.coll, bson.M{"ip": ip})
-
+func (o *IPForbidden) Take(ctx context.Context, ip string) (*admindb.IPForbidden, error) {
+	return mongoutil.FindOne[*admindb.IPForbidden](ctx, o.coll, bson.M{"ip": ip})
 }
 
-func (o *IPForbidden) Find(ctx context.Context, ips []string) ([]*admin.IPForbidden, error) {
-	return mongoutil.Find[*admin.IPForbidden](ctx, o.coll, bson.M{"ip": bson.M{"$in": ips}})
-
+func (o *IPForbidden) Find(ctx context.Context, ips []string) ([]*admindb.IPForbidden, error) {
+	return mongoutil.Find[*admindb.IPForbidden](ctx, o.coll, bson.M{"ip": bson.M{"$in": ips}})
 }
 
-func (o *IPForbidden) Search(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*admin.IPForbidden, error) {
+func (o *IPForbidden) Search(ctx context.Context, keyword string, state int32, pagination pagination.Pagination) (int64, []*admindb.IPForbidden, error) {
 	filter := bson.M{}
 
 	switch state {
@@ -81,10 +80,10 @@ func (o *IPForbidden) Search(ctx context.Context, keyword string, state int32, p
 			{"ip": bson.M{"$regex": keyword, "$options": "i"}},
 		}
 	}
-	return mongoutil.FindPage[*admin.IPForbidden](ctx, o.coll, filter, pagination)
+	return mongoutil.FindPage[*admindb.IPForbidden](ctx, o.coll, filter, pagination)
 }
 
-func (o *IPForbidden) Create(ctx context.Context, ms []*admin.IPForbidden) error {
+func (o *IPForbidden) Create(ctx context.Context, ms []*admindb.IPForbidden) error {
 	return mongoutil.InsertMany(ctx, o.coll, ms)
 }
 

--- a/pkg/common/db/model/admin/limit_user_login_ip.go
+++ b/pkg/common/db/model/admin/limit_user_login_ip.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"
@@ -75,7 +76,6 @@ func (o *LimitUserLoginIP) Search(ctx context.Context, keyword string, paginatio
 		},
 	}
 	return mongoutil.FindPage[*admin.LimitUserLoginIP](ctx, o.coll, filter, pagination)
-
 }
 
 func (o *LimitUserLoginIP) limitUserLoginIPFilter(ips []*admin.LimitUserLoginIP) bson.M {

--- a/pkg/common/db/model/admin/register_add_friend.go
+++ b/pkg/common/db/model/admin/register_add_friend.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"

--- a/pkg/common/db/model/admin/register_add_group.go
+++ b/pkg/common/db/model/admin/register_add_group.go
@@ -16,6 +16,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/pagination"
 	"go.mongodb.org/mongo-driver/bson"

--- a/pkg/common/imapi/call.go
+++ b/pkg/common/imapi/call.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
-	pconstant "github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/errs"
 	"github.com/openimsdk/tools/log"
 	"gorm.io/gorm/utils"
@@ -75,10 +75,10 @@ func (a caller[Req, Resp]) call(ctx context.Context, apiPrefix string, req *Req)
 	if err != nil {
 		return nil, err
 	}
-	operationID := utils.ToString(ctx.Value(pconstant.OperationID))
-	request.Header.Set(pconstant.OperationID, operationID)
+	operationID := utils.ToString(ctx.Value(constantpb.OperationID))
+	request.Header.Set(constantpb.OperationID, operationID)
 	if token, _ := ctx.Value(constant.CtxApiToken).(string); token != "" {
-		request.Header.Set(pconstant.Token, token)
+		request.Header.Set(constantpb.Token, token)
 	}
 	response, err := client.Do(request)
 	if err != nil {

--- a/pkg/common/imapi/caller.go
+++ b/pkg/common/imapi/caller.go
@@ -16,12 +16,13 @@ package imapi
 
 import (
 	"context"
-	"github.com/openimsdk/tools/log"
 	"sync"
 	"time"
 
+	"github.com/openimsdk/tools/log"
+
 	"github.com/openimsdk/protocol/auth"
-	"github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/protocol/friend"
 	"github.com/openimsdk/protocol/group"
 	"github.com/openimsdk/protocol/sdkws"
@@ -74,7 +75,7 @@ func (c *Caller) ImAdminTokenWithDefaultAdmin(ctx context.Context) (string, erro
 	defer c.lock.Unlock()
 	if c.token == "" || c.timeout.Before(time.Now()) {
 		userID := c.defaultIMUserID
-		token, err := c.UserToken(ctx, userID, constant.AdminPlatformID)
+		token, err := c.UserToken(ctx, userID, constantpb.AdminPlatformID)
 		if err != nil {
 			log.ZError(ctx, "get im admin token", err, "userID", userID)
 			return "", err
@@ -127,7 +128,7 @@ func (c *Caller) RegisterUser(ctx context.Context, users []*sdkws.UserInfo) erro
 }
 
 func (c *Caller) ForceOffLine(ctx context.Context, userID string) error {
-	for id := range constant.PlatformID2Name {
+	for id := range constantpb.PlatformID2Name {
 		_, _ = forceOffLine.Call(ctx, c.imApi, &auth.ForceLogoutReq{
 			PlatformID: int32(id),
 			UserID:     userID,

--- a/pkg/common/mctx/get.go
+++ b/pkg/common/mctx/get.go
@@ -16,10 +16,12 @@ package mctx
 
 import (
 	"context"
-	"github.com/openimsdk/tools/utils/datautil"
 	"strconv"
 
-	constant2 "github.com/openimsdk/protocol/constant"
+
+	"github.com/openimsdk/tools/utils/datautil"
+
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/errs"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
@@ -103,7 +105,7 @@ func CheckAdminOr(ctx context.Context, userIDs ...string) error {
 }
 
 func GetOpUserID(ctx context.Context) string {
-	userID, _ := ctx.Value(constant2.OpUserID).(string)
+	userID, _ := ctx.Value(constantpb.OpUserID).(string)
 	return userID
 }
 

--- a/pkg/protocol/chat/chat.go
+++ b/pkg/protocol/chat/chat.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 
 	"github.com/openimsdk/chat/pkg/common/constant"
-	pconstant "github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/errs"
 )
 
@@ -116,7 +116,7 @@ func (x *RegisterUserReq) Check() error {
 	if x.User.Nickname == "" {
 		return errs.ErrArgs.WrapMsg("Nickname is nil")
 	}
-	if x.Platform < pconstant.IOSPlatformID || x.Platform > pconstant.AdminPlatformID {
+	if x.Platform < constantpb.IOSPlatformID || x.Platform > constantpb.AdminPlatformID {
 		return errs.ErrArgs.WrapMsg("platform is invalid")
 	}
 	if x.User == nil {
@@ -142,7 +142,7 @@ func (x *RegisterUserReq) Check() error {
 }
 
 func (x *LoginReq) Check() error {
-	if x.Platform < pconstant.IOSPlatformID || x.Platform > pconstant.AdminPlatformID {
+	if x.Platform < constantpb.IOSPlatformID || x.Platform > constantpb.AdminPlatformID {
 		return errs.ErrArgs.WrapMsg("platform is invalid")
 	}
 	if x.Email == "" {

--- a/tools/check-component/main.go
+++ b/tools/check-component/main.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"path/filepath"
+	"time"
+
 	"github.com/openimsdk/chat/pkg/common/cmd"
 	"github.com/openimsdk/chat/pkg/common/config"
 	"github.com/openimsdk/chat/pkg/common/imapi"
-	"github.com/openimsdk/protocol/constant"
+	constantpb "github.com/openimsdk/protocol/constant"
 	"github.com/openimsdk/tools/db/mongoutil"
 	"github.com/openimsdk/tools/db/redisutil"
 	"github.com/openimsdk/tools/discovery/etcd"
@@ -29,8 +32,6 @@ import (
 	"github.com/openimsdk/tools/mcontext"
 	"github.com/openimsdk/tools/system/program"
 	"github.com/openimsdk/tools/utils/idutil"
-	"path/filepath"
-	"time"
 )
 
 const maxRetry = 180
@@ -56,8 +57,8 @@ func CheckRedis(ctx context.Context, config *config.Redis) error {
 }
 
 func CheckOpenIM(ctx context.Context, apiURL, secret, adminUserID string) error {
-	api2 := imapi.New(apiURL, secret, adminUserID)
-	_, err := api2.UserToken(mcontext.SetOperationID(ctx, "CheckOpenIM"+idutil.OperationIDGenerator()), adminUserID, constant.AdminPlatformID)
+	imAPI := imapi.New(apiURL, secret, adminUserID)
+	_, err := imAPI.UserToken(mcontext.SetOperationID(ctx, "CheckOpenIM"+idutil.OperationIDGenerator()), adminUserID, constantpb.AdminPlatformID)
 	return err
 }
 


### PR DESCRIPTION
#### 🅰 Please add the issue ID after "Fixes #"
Fixes #548

meanwhile, I fixed it `internal/rpc/chat/password.go` is uncorrect error handle.