### PR TITLE
fix: SearchFriend can search email

### DIFF
--- a/pkg/common/db/model/chat/attribute.go
+++ b/pkg/common/db/model/chat/attribute.go
@@ -164,6 +164,7 @@ func (o *Attribute) SearchUser(ctx context.Context, keyword string, userIDs []st
 			{"account": bson.M{"$regex": keyword, "$options": "i"}},
 			{"nickname": bson.M{"$regex": keyword, "$options": "i"}},
 			{"phone_number": bson.M{"$regex": keyword, "$options": "i"}},
+			{"email": bson.M{"$regex": keyword, "$options": "i"}},
 		}
 	}
 	return mongoutil.FindPage[*chat.Attribute](ctx, o.coll, filter, pagination)


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #599
fix: SearchFriend can search email