### PR TITLE
fix:  When the phone verification code is not passed in, the enable rule of the phone verification code still takes effect

### DIFF
--- a/internal/rpc/chat/login.go
+++ b/internal/rpc/chat/login.go
@@ -102,7 +102,7 @@ func (o *chatSvr) SendVerifyCode(ctx context.Context, req *chat.SendVerifyCodeRe
 		}
 	}
 
-	if req.AreaCode == "" {
+	if req.AreaCode != "" {
 		switch o.conf.Phone.Use {
 		case constant.VerifySuperCode:
 			return &chat.SendVerifyCodeResp{}, nil // super code


### PR DESCRIPTION

## 🅰 Please add the issue ID after "Fixes #"

Fixes #646
